### PR TITLE
Basic udev rule

### DIFF
--- a/udev/99-corsair-link.rules
+++ b/udev/99-corsair-link.rules
@@ -1,0 +1,1 @@
+SUBSYSTEM=="hidraw", KERNEL=="hidraw*", ENV{DEVPATH}=="*:1B1C:0C04.*/hidraw/hidraw*", MODE="0660", GROUP="usb"


### PR DESCRIPTION
For Linux: based on device ID and vendor ID, this allows non-root access for users in the `usb` group. It is for example only, not for direct installation. However, it works on Gentoo if placed at `/etc/udev/rules.d/`. Some distributions use different groups (like `plugdev`) or may want a completely separate group for devices like these (maybe a group named `hwmon`) for security reasons.

`udevadm info /dev/hidraw1`:

```
P: /devices/pci0000:00/0000:00:14.0/usb3/3-11/3-11:1.0/0003:1B1C:0C04.0002/hidraw/hidraw1
N: hidraw1
E: DEVNAME=/dev/hidraw1
E: DEVPATH=/devices/pci0000:00/0000:00:14.0/usb3/3-11/3-11:1.0/0003:1B1C:0C04.0002/hidraw/hidraw1
E: MAJOR=250
E: MINOR=1
E: SUBSYSTEM=hidraw
```

Open to suggestions on the matching rule, but based on the above information matching with `ATTRS{idVendor}` and similar is not possible for the HID device. You can match the USB device but this has no effect on the permissions of the `/dev/hidraw*` file.

