### PR TITLE
Adding support for RM850i. TX Buffer size fix for linux.

### DIFF
--- a/device.c
+++ b/device.c
@@ -129,6 +129,18 @@ struct corsair_device_info corsairlink_devices[] = {
 		.fan_control_count = 1,
 		.pump_index = 0,
 	},
+	{
+		.vendor_id = 0x1b1c,
+		.product_id = 0x1c0c,
+		.device_id = 0xFF,
+		.name = "RM850i",
+		.read_endpoint = 0x01|LIBUSB_ENDPOINT_IN,
+		.write_endpoint = 0x01|LIBUSB_ENDPOINT_OUT,
+		.driver = &corsairlink_driver_rmi,
+		.led_control_count = 0,
+		.fan_control_count = 1,
+		.pump_index = 0,
+	},
 };
 
 size_t corsairlink_device_count = sizeof(corsairlink_devices)/sizeof(corsairlink_devices[0]);

--- a/protocol/rmi/core.c
+++ b/protocol/rmi/core.c
@@ -66,15 +66,14 @@ int corsairlink_rmi_name(struct corsair_device_info *dev, struct libusb_device_h
 {
 	int r;
 	uint8_t response[64];
-	uint8_t commands[32];
+	uint8_t commands[64];
 	memset(response, 0, sizeof(response));
 	memset(commands, 0, sizeof(commands));
 
 	commands[0] = 0xfe;
 	commands[1] = 0x03;
-	commands[2] = 0x00;
 
-	r = dev->driver->write(handle, dev->write_endpoint, commands, 2);
+	r = dev->driver->write(handle, dev->write_endpoint, commands, 64);
 	r = dev->driver->read(handle, dev->read_endpoint, response, 64);
 
 	memcpy(name, response+2, 16);
@@ -86,7 +85,7 @@ int corsairlink_rmi_vendor(struct corsair_device_info *dev, struct libusb_device
 {
 	int r;
 	uint8_t response[64];
-	uint8_t commands[32];
+	uint8_t commands[64];
 	memset(response, 0, sizeof(response));
 	memset(commands, 0, sizeof(commands));
 
@@ -94,7 +93,7 @@ int corsairlink_rmi_vendor(struct corsair_device_info *dev, struct libusb_device
 	commands[1] = 0x99;
 	commands[2] = 0x00;
 
-	r = dev->driver->write(handle, dev->write_endpoint, commands, 2);
+	r = dev->driver->write(handle, dev->write_endpoint, commands, 64);
 	r = dev->driver->read(handle, dev->read_endpoint, response, 64);
 
 	memcpy(name, response+2, 16);
@@ -106,7 +105,7 @@ int corsairlink_rmi_product(struct corsair_device_info *dev, struct libusb_devic
 {
 	int r;
 	uint8_t response[64];
-	uint8_t commands[32];
+	uint8_t commands[64];
 	memset(response, 0, sizeof(response));
 	memset(commands, 0, sizeof(commands));
 
@@ -114,7 +113,7 @@ int corsairlink_rmi_product(struct corsair_device_info *dev, struct libusb_devic
 	commands[1] = 0x9a;
 	commands[2] = 0x00;
 
-	r = dev->driver->write(handle, dev->write_endpoint, commands, 2);
+	r = dev->driver->write(handle, dev->write_endpoint, commands, 64);
 	r = dev->driver->read(handle, dev->read_endpoint, response, 64);
 
 	memcpy(name, response+2, 16);

--- a/protocol/rmi/fan.c
+++ b/protocol/rmi/fan.c
@@ -23,7 +23,7 @@ int corsairlink_rmi_fan_rpm(struct corsair_device_info *dev, struct libusb_devic
 {
 	int r;
 	uint8_t response[64];
-	uint8_t commands[32];
+	uint8_t commands[64];
 	memset(response, 0, sizeof(response));
 	memset(commands, 0, sizeof(commands));
 
@@ -32,9 +32,9 @@ int corsairlink_rmi_fan_rpm(struct corsair_device_info *dev, struct libusb_devic
 	commands[2] = 0x00;
 	commands[3] = 0x00;
 
-	r = dev->driver->write(handle, dev->write_endpoint, commands, 4);
+	r = dev->driver->write(handle, dev->write_endpoint, commands, 64);
 	r = dev->driver->read(handle, dev->read_endpoint, response, 64);
 
-	rpm = 
-	return 0;	
+//	rpm = 0;
+	return 0;
 }

--- a/protocol/rmi/power.c
+++ b/protocol/rmi/power.c
@@ -38,7 +38,7 @@ int corsairlink_rmi_output_select(struct corsair_device_info *dev,
 {
 	int r;
 	uint8_t response[64];
-	uint8_t commands[32] ;
+	uint8_t commands[64] ;
 	memset(response, 0, sizeof(response));
 	memset(commands, 0, sizeof(commands));
 
@@ -48,7 +48,7 @@ int corsairlink_rmi_output_select(struct corsair_device_info *dev,
 	commands[1] = 0x00; // Command Opcode: Output X Select
 	commands[2] = output_select; // Command data...
 
-	r = dev->driver->write(handle, dev->write_endpoint, commands, 3);
+	r = dev->driver->write(handle, dev->write_endpoint, commands, 64);
 	r = dev->driver->read(handle, dev->read_endpoint, response, 64);
 
 	return 0;
@@ -60,7 +60,7 @@ int corsairlink_rmi_output_volts(struct corsair_device_info *dev,
 {
 	int r;
 	uint8_t response[64];
-	uint8_t commands[32] ;
+	uint8_t commands[64] ;
 	memset(response, 0, sizeof(response));
 	memset(commands, 0, sizeof(commands));
 
@@ -72,7 +72,7 @@ int corsairlink_rmi_output_volts(struct corsair_device_info *dev,
 	commands[2] = 0x00; // Command data...
 	commands[3] = 0x00;
 
-	r = dev->driver->write(handle, dev->write_endpoint, commands, 4);
+	r = dev->driver->write(handle, dev->write_endpoint, commands, 64);
 	r = dev->driver->read(handle, dev->read_endpoint, response, 64);
 
 	memcpy(volts, response+2, 2);
@@ -91,7 +91,7 @@ int corsairlink_rmi_output_amps(struct corsair_device_info *dev,
 {
 	int r;
 	uint8_t response[64];
-	uint8_t commands[32] ;
+	uint8_t commands[64] ;
 	memset(response, 0, sizeof(response));
 	memset(commands, 0, sizeof(commands));
 
@@ -102,7 +102,7 @@ int corsairlink_rmi_output_amps(struct corsair_device_info *dev,
 	commands[2] = 0x00; // Command data...
 	commands[3] = 0x00;
 
-	r = dev->driver->write(handle, dev->write_endpoint, commands, 4);
+	r = dev->driver->write(handle, dev->write_endpoint, commands, 64);
 	r = dev->driver->read(handle, dev->read_endpoint, response, 64);
 	memcpy(amps, response+2, 2);
 
@@ -119,7 +119,7 @@ int corsairlink_rmi_output_watts(struct corsair_device_info *dev,
 {
 	int r;
 	uint8_t response[64];
-	uint8_t commands[32] ;
+	uint8_t commands[64];
 	memset(response, 0, sizeof(response));
 	memset(commands, 0, sizeof(commands));
 
@@ -130,7 +130,7 @@ int corsairlink_rmi_output_watts(struct corsair_device_info *dev,
 	commands[2] = 0x00; // Command data...
 	commands[3] = 0x00;
 
-	r = dev->driver->write(handle, dev->write_endpoint, commands, 4);
+	r = dev->driver->write(handle, dev->write_endpoint, commands, 64);
 	r = dev->driver->read(handle, dev->read_endpoint, response, 64);
 
 	memcpy(watts, response+2, 2);
@@ -177,7 +177,7 @@ int corsairlink_rmi_power_total_wattage(struct corsair_device_info *dev,
 {
 	int r;
 	uint8_t response[64];
-	uint8_t commands[32] ;
+	uint8_t commands[64];
 	memset(response, 0, sizeof(response));
 	memset(commands, 0, sizeof(commands));
 
@@ -188,7 +188,7 @@ int corsairlink_rmi_power_total_wattage(struct corsair_device_info *dev,
 	commands[2] = 0x00; // Command data...
 	commands[3] = 0x00;
 
-	r = dev->driver->write(handle, dev->write_endpoint, commands, 4);
+	r = dev->driver->write(handle, dev->write_endpoint, commands, 64);
 	r = dev->driver->read(handle, dev->read_endpoint, response, 64);
 
 	memcpy(watts, response+2, 2);

--- a/protocol/rmi/temperature.c
+++ b/protocol/rmi/temperature.c
@@ -36,7 +36,7 @@ int corsairlink_rmi_temperature(struct corsair_device_info *dev, struct libusb_d
 {
 	int r;
 	uint8_t response[64];
-	uint8_t commands[32];
+	uint8_t commands[64];
 	memset(response, 0, sizeof(response));
 	memset(commands, 0, sizeof(commands));
 
@@ -45,7 +45,7 @@ int corsairlink_rmi_temperature(struct corsair_device_info *dev, struct libusb_d
 	commands[2] = 0x00;
 	commands[3] = 0x00;
 
-	r = dev->driver->write(handle, dev->write_endpoint, commands, 4);
+	r = dev->driver->write(handle, dev->write_endpoint, commands, 64);
 	r = dev->driver->read(handle, dev->read_endpoint, response, 64);
 
 	memcpy(temperature, response+2, 2);

--- a/protocol/rmi/time.c
+++ b/protocol/rmi/time.c
@@ -35,7 +35,7 @@ int corsairlink_rmi_time_powered(struct corsair_device_info *dev, struct libusb_
 {
 	int r;
 	uint8_t response[64];
-	uint8_t commands[32];
+	uint8_t commands[64];
 	memset(response, 0, sizeof(response));
 	memset(commands, 0, sizeof(commands));
 
@@ -46,7 +46,7 @@ int corsairlink_rmi_time_powered(struct corsair_device_info *dev, struct libusb_
 	commands[4] = 0x00;
 	commands[5] = 0x00;
 
-	r = dev->driver->write(handle, dev->write_endpoint, commands, 6);
+	r = dev->driver->write(handle, dev->write_endpoint, commands, 64);
 	r = dev->driver->read(handle, dev->read_endpoint, response, 64);
 
 	memcpy(powered, response+2, 4);
@@ -58,7 +58,7 @@ int corsairlink_rmi_time_uptime(struct corsair_device_info *dev, struct libusb_d
 {
 	int r;
 	uint8_t response[64];
-	uint8_t commands[32];
+	uint8_t commands[64];
 	memset(response, 0, sizeof(response));
 	memset(commands, 0, sizeof(commands));
 
@@ -69,7 +69,7 @@ int corsairlink_rmi_time_uptime(struct corsair_device_info *dev, struct libusb_d
 	commands[4] = 0x00;
 	commands[5] = 0x00;
 
-	r = dev->driver->write(handle, dev->write_endpoint, commands, 6);
+	r = dev->driver->write(handle, dev->write_endpoint, commands, 64);
 	r = dev->driver->read(handle, dev->read_endpoint, response, 64);
 
 	memcpy(uptime, response+2, 4);


### PR DESCRIPTION
Hi,

I made a couple changes to make it work on my system.

```
./OpenCorsairLink.elf --device 0
Dev=0, CorsairLink Device Found: RM850i!

Vendor: CORSAIR
Product: RM850i
Firmware: NA
Temperature 0: 61.50 C
Temperature 1: 42.00 C
Powered: 721840 (8d.  8h)
Uptime: 30640 (0d.  8h)
Supply Voltage: 230.00
Total Watts: 392.00
Output 12v:
        Voltage 12.19
        Amps 30.00
        Watts 364.00
Output 5v:
        Voltage  5.06
        Amps  3.50
        Watts 18.00
Output 3.3v:
        Voltage  3.38
        Amps  3.12
        Watts 10.00

```