### PR TITLE
Default to show info for all detected devices.

### DIFF
--- a/main.c
+++ b/main.c
@@ -183,7 +183,7 @@ int main(int argc, char *argv[])
 	}
 	libusb_set_debug(context, 3);
 
-	corsairlink_device_scanner(context);
+	int device_count = corsairlink_device_scanner(context);
 	msg_debug("DEBUG: scan done, start routines\n");
 	msg_debug("DEBUG: device_number = %d\n", device_number);
 
@@ -192,6 +192,14 @@ int main(int argc, char *argv[])
 			psu_settings(scanlist[device_number], settings);
 		} else {
 			hydro_settings(scanlist[device_number], settings);
+		}
+	} else {
+		for (int i=0; i<device_count; i++) {
+			if (scanlist[i].device->driver == &corsairlink_driver_rmi) {
+				psu_settings(scanlist[i], settings);
+			} else {
+				hydro_settings(scanlist[i], settings);
+			}
 		}
 	}
 

--- a/scan.c
+++ b/scan.c
@@ -107,5 +107,5 @@ int corsairlink_device_scanner(libusb_context *context)
 	msg_info("\n");
 	/* End: scan code */
 
-	return 0;
+	return scanlist_count;
 }


### PR DESCRIPTION
Instead of just showing detected devices, also show current info. Note there is currently no command to show all info from a device. Only one piece of info at a time. I think most use cases would be someone just running the command to see if it works and see temp, fan speed, etc. from there current setup.