### PR TITLE
Fix device.h: No such file or directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,8 @@
 #
 
 CC ?= gcc
-CFLAGS ?= -std=c99 -pedantic-errors -Iinclude
+CFLAGS ?= -std=c99 -pedantic-errors
+CFLAGS += -Iinclude
 LDFLAGS ?= -lm
 
 # pkg-config for libusb-1.0


### PR DESCRIPTION
Without adding the include directory to CFLAGS it fails to compile if CFLAGS was defined in the shell with this error:
make 
cc -march=k8 -O2 -pipe -mmmx -msse -msse2 -msse3 -I/usr/include/libusb-1.0 -g -c -o main.o main.c
main.c:25:20: fatal error: device.h: No such file or directory
 #include "device.h"
                    ^
compilation terminated.
make: *** [Makefile:79: main.o] Error 1

Now -Iinclude is always appended.