### PR TITLE
Fix big/little endian confusion in commander pro temperature readout

### DIFF
--- a/protocol/commanderpro/temperature.c
+++ b/protocol/commanderpro/temperature.c
@@ -80,7 +80,7 @@ corsairlink_commanderpro_temperature(
     rr = dev->driver->read( handle, dev->read_endpoint, response, 16 );
 
     uint16_t data;
-    memcpy( &data, response + 1, 2 );
+    data = ( response[1] << 8 ) + response[2];
     *( temperature ) = (double)data / 100;
     // snprintf(temperature, temperature_str_len, "%5.2f C", (double)data/100);
 


### PR DESCRIPTION
## Proposed changes

The temperatures are reported in big endian by the device. The voltages are returned from the device in the same way where the endianness was flipped correctly, so I copied the code from there.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/audiohacked/OpenCorsairLink/blob/testing/CONTRIBUTING.md) doc
- [ ] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your master!
- [x] Make sure you are making a pull request against the **testing branch** (left side). Also you should start *your branch* off *our testing*.
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Check the commit's or even all commits' message styles matches our requested structure.
