### PR TITLE
fixes timeout issue with H150i Pro

### DIFF
--- a/lowlevel/asetek.c
+++ b/lowlevel/asetek.c
@@ -36,10 +36,10 @@ corsairlink_asetek_init( struct libusb_device_handle* dev_handle, uint8_t endpoi
     int rr;
 
     rr = libusb_control_transfer( dev_handle, 0x40, 0x00, 0xffff, 0x0000, NULL, 0, 0 );
-    if (rr < 0)
-    {
-        return rr;
-    }
+    // if (rr < 0)
+    // {
+    //     return rr;
+    // }
     rr = libusb_control_transfer( dev_handle, 0x40, 0x02, 0x0002, 0x0000, NULL, 0, 0 );
 
     return rr;


### PR DESCRIPTION
## Proposed changes

There appears to be some failsafe in asetek.c that exits early from the `corsairlink_asetek_init` function. Maybe this is needed for some of the other hardware, but this is the source of the timeout failures with my H150i Pro. Simply commenting this return out and leaving the function otherwise as it is in the master branch allows all of the LED and pump settings to apply correctly:

`sudo /usr/local/bin/OpenCorsairLink.elf --device 0 --led channel=1,mode=0,colors=000000 --pump mode=5 --debug`
```
Checking USB device 0 (redacted)...
Checking USB device 1 (redacted)...
Checking USB device 2 (redacted)...
Checking USB device 3 (redacted)...
Checking USB device 4 (redacted)...
Checking USB device 5 (redacted)...
Checking USB device 6 (redacted)...
Checking USB device 7 (redacted)...
Checking USB device 8 (redacted)...
Checking USB device 9 (redacted)...
Checking USB device 10 (redacted)...
Checking USB device 11 (redacted)...
Checking USB device 12 (redacted)...
Checking USB device 13 (redacted)...
Checking USB device 14 (redacted)...
Checking USB device 15 (redacted)...
Checking USB device 16 (1b1c:0c12)...
Corsair product detected. Checking if device is H150i Pro... Unable to detach kernel driver from Corsair Device
Dev=0, CorsairLink Device Found: H150i Pro!
Checking USB device 17 (redacted)...

DEBUG: scan done, start routines
DEBUG: selected device_number = 0
DEBUG: shortcuts set
DEBUG: init done
Vendor: Corsair
Product: H150i Pro
AA 12 34 01 00 04 00
Firmware: 1.0.4.0
hardware version returned: AB 12 34 02 00 00 00
A9 12 34 1F 01
Temperature 0: 31.10 C
00
41 12 34 00 06 03
Fan 0:	Mode 0x00
	Current/Max Speed 1539/0 RPM
00
41 12 34 01 05 EE
Fan 1:	Mode 0x00
	Current/Max Speed 1518/0 RPM
00
41 12 34 02 05 F7
Fan 2:	Mode 0x00
	Current/Max Speed 1527/0 RPM
function:corsairlink_asetekpro_pump_mode_read file: protocol/asetekpro/pump.c
pump mode response = 33 12 34 02
pump speed response = 31 12 34 0A E6
Pump:	Mode 0x02 (AsetekProPumpPerformance)
	Current/Max Speed 2790/0 RPM
Setting LED Flag found
Setting LED STATIC
DEBUG: Color0 000000
DEBUG: Color1 ff8000
DEBUG: Color2 ffff00
DEBUG: Color3 00ff00
DEBUG: Color4 0000ff
DEBUG: Color5 4b0082
DEBUG: Color6 7f00ff
56 12 34
55 12 34
Setting pump to mode: 5
pump write performance response = 32 12 34 00 00
function:corsairlink_asetekpro_pump_mode_read file: protocol/asetekpro/pump.c
pump mode response = 33 12 34 02
DEBUG: deinit done
Unable to attach kernel driver to USB device
```