### PR TITLE
Set libusb to automatically detach/attach the kernel driver

### DIFF
--- a/logic/scan.c
+++ b/logic/scan.c
@@ -44,11 +44,6 @@ corsairlink_handle_close( struct libusb_device_handle* handle )
         msg_err("Unable to release USB interface\n");
     }
 
-    rr = libusb_attach_kernel_driver( handle, 0 );
-    if ( rr < 0 )
-    {
-        msg_debug("Unable to attach kernel driver to USB device\n");
-    }
     libusb_close( handle );
 
     return rr;
@@ -107,11 +102,10 @@ corsairlink_device_scanner( libusb_context* context, int* _scanlist_count )
                 rr = libusb_open( devices[ii], &scanlist[scanlist_count].handle );
                 if ( scanlist[scanlist_count].handle != NULL )
                 { // Maybe try 'if (rr == 0)'
-                    rr = libusb_detach_kernel_driver( scanlist[scanlist_count].handle, 0 );
-                    if ( rr < 0 )
+                    rr = libusb_set_auto_detach_kernel_driver( scanlist[scanlist_count].handle, 1 );
+                    if ( rr != LIBUSB_SUCCESS )
                     {
-                        msg_debug("Unable to detach kernel driver from Corsair Device\n");
-                        // return rr;
+                        msg_err("Platform does not support kernel detachment\n");
                     }
 
                     rr = libusb_claim_interface( scanlist[scanlist_count].handle, 0 );


### PR DESCRIPTION
## Proposed changes

Both libusb_detach_kernel_driver and libusb_attach_kernel_driver are
perfectly fine to return errors if there was no kernel bound to the
device in the first place.

Instead of tracking that ourselves, just set libusb to do it automatically.

> When this is enabled libusb will automatically detach the kernel driver
> on an interface when claiming the interface, and attach it when
> releasing the interface.

libusb_set_auto_detach_kernel_driver will only fail if on that platform
libusb cannot detach a kernel driver in the first place.  As this can
happen simply because detaching the kernel driver is not required for
libusb to work on the platform, only emit a warning but carry on.

This patch was tested on Linux with a dummy device (not from Corsair,
but compatible with the Asetek code), both with and without having a
kernel driver bound to it first.

Fixes: #193
Related: #134

## Types of changes

What types of changes does your code introduce to Appium?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/audiohacked/OpenCorsairLink/blob/testing/CONTRIBUTING.md) doc
- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your master!
- [x] Make sure you are making a pull request against the **testing branch** (left side). Also you should start *your branch* off *our testing*.
- [ ] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] (not applicable) I have added necessary documentation (if appropriate)
- [x] (not applicable) Any dependent changes have been merged and published in downstream modules
- [x] Check the commit's or even all commits' message styles matches our requested structure.