### PR TITLE
Fix where to read Hydro Asetek fan speeds from

### DIFF
--- a/logic/settings/hydro_asetek.c
+++ b/logic/settings/hydro_asetek.c
@@ -83,10 +83,10 @@ hydro_asetek_settings(
         rr = dev->driver->fan.speed( dev, handle, &readings.fan_ctrl );
         msg_info( "Fan %d:\t%s\n", ii, readings.fan_ctrl.mode_string );
         msg_info(
-            "\tCurrent/Max Speed %i/%i RPM\n", readings.fan_ctrl.speed_rpm,
+            "\tCurrent/Max Speed %i/%i RPM\n", readings.fan_ctrl.speed,
             readings.fan_ctrl.max_speed );
         msg_machine(
-            "fan:%d:%d:%i:%i\n", ii, readings.fan_ctrl.mode, readings.fan_ctrl.speed_rpm,
+            "fan:%d:%d:%i:%i\n", ii, readings.fan_ctrl.mode, readings.fan_ctrl.speed,
             readings.fan_ctrl.max_speed );
     }
 


### PR DESCRIPTION
Fixes: #142 ("H100i GT V2 fan current/max speed 0")

## Proposed changes

Struct fan_ctrl has both speed and speed_rpm fields.  The driver for Hydro Asetek devices stores the fan speed in the former, but we were accessing the latter.

This PR only fixes the Hydro Asetek driver.  While the speed_rpm field [might simply be some leftover from legacy code](), it is still used in other drivers and, from a quick glance, possibly correctly so.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/audiohacked/OpenCorsairLink/blob/testing/CONTRIBUTING.md) doc
- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your master!
- [x] Make sure you are making a pull request against the **testing branch** (left side). Also you should start *your branch* off *our testing*.
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests tested that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] Check the commit's or even all commits' message styles matches our requested structure.