### PR TITLE
Use the Homebrew addon on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,10 +13,10 @@ addons:
         update: true
         packages:
         - libusb-1.0-0-dev
-
-before_install:
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update         ; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install libusb ; fi
+    homebrew:
+        packages:
+        - libusb
+        update: true
 
 script:
     - make


### PR DESCRIPTION
## Proposed changes

With the latest release of libusb on Homebrew, a warning when ensuring
it's installed became an error.

```
  $ if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install libusb ; fi
- Warning: libusb 1.0.22 is already installed and up-to-date
- To reinstall 1.0.22, run `brew reinstall libusb`
+ Error: libusb 1.0.22 is already installed
+ To upgrade to 1.0.23, run `brew upgrade libusb`.
```

Instead of manually dealing with this, delegate to Travis.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/audiohacked/OpenCorsairLink/blob/testing/CONTRIBUTING.md) doc
- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your master!
- [x] Make sure you are making a pull request against the **testing branch** (left side). Also you should start *your branch* off *our testing*.
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] Check the commit's or even all commits' message styles matches our requested structure.