### PR TITLE
options: Document balanced pump mode

### DIFF
--- a/logic/options.c
+++ b/logic/options.c
@@ -159,6 +159,7 @@ options_print( void )
     msg_info( "\n" );
     msg_info( "\t\tModes:\n" );
     msg_info( "\t\t\t 3 - Quiet\n" );
+    msg_info( "\t\t\t 4 - Balanced\n" );
     msg_info( "\t\t\t 5 - Performance\n" );
 
     msg_info( "\n Without options, OpenCorsairLink will show the status of any "


### PR DESCRIPTION
--pump mode=4 for Balanced mode is not documented in the --help output

Fixes #208