### PR TITLE
Fix .write_endpoint values for HIDs without an OUT endpoint

### DIFF
--- a/device.c
+++ b/device.c
@@ -53,8 +53,7 @@ struct corsair_device_info corsairlink_devices[] = {
         .device_id = 0x37,
         .name = "H80",
         .read_endpoint = 0x01 | LIBUSB_ENDPOINT_IN,
-        .write_endpoint =
-            LIBUSB_REQUEST_TYPE_CLASS | LIBUSB_RECIPIENT_INTERFACE | LIBUSB_ENDPOINT_OUT,
+        .write_endpoint = 0x00 | LIBUSB_ENDPOINT_OUT,
         .driver = &corsairlink_driver_coolit,
         .led_control_count = 1,
         .fan_control_count = 4,
@@ -67,8 +66,7 @@ struct corsair_device_info corsairlink_devices[] = {
         .device_id = 0x38,
         .name = "Cooling Node",
         .read_endpoint = 0x01 | LIBUSB_ENDPOINT_IN,
-        .write_endpoint =
-            LIBUSB_REQUEST_TYPE_CLASS | LIBUSB_RECIPIENT_INTERFACE | LIBUSB_ENDPOINT_OUT,
+        .write_endpoint = 0x00 | LIBUSB_ENDPOINT_OUT,
         .driver = &corsairlink_driver_coolit,
         .led_control_count = 1,
         .fan_control_count = 4,
@@ -81,8 +79,7 @@ struct corsair_device_info corsairlink_devices[] = {
         .device_id = 0x39,
         .name = "Lighting Node",
         .read_endpoint = 0x01 | LIBUSB_ENDPOINT_IN,
-        .write_endpoint =
-            LIBUSB_REQUEST_TYPE_CLASS | LIBUSB_RECIPIENT_INTERFACE | LIBUSB_ENDPOINT_OUT,
+        .write_endpoint = 0x00 | LIBUSB_ENDPOINT_OUT,
         .driver = &corsairlink_driver_coolit,
         .led_control_count = 1,
         .fan_control_count = 4,
@@ -94,8 +91,7 @@ struct corsair_device_info corsairlink_devices[] = {
         .device_id = 0x3a,
         .name = "H100",
         .read_endpoint = 0x01 | LIBUSB_ENDPOINT_IN,
-        .write_endpoint =
-            LIBUSB_REQUEST_TYPE_CLASS | LIBUSB_RECIPIENT_INTERFACE | LIBUSB_ENDPOINT_OUT,
+        .write_endpoint = 0x00 | LIBUSB_ENDPOINT_OUT,
         .driver = &corsairlink_driver_coolit,
         .led_control_count = 1,
         .fan_control_count = 4,
@@ -108,8 +104,7 @@ struct corsair_device_info corsairlink_devices[] = {
         .device_id = 0x3b,
         .name = "H80i",
         .read_endpoint = 0x01 | LIBUSB_ENDPOINT_IN,
-        .write_endpoint =
-            LIBUSB_REQUEST_TYPE_CLASS | LIBUSB_RECIPIENT_INTERFACE | LIBUSB_ENDPOINT_OUT,
+        .write_endpoint = 0x00 | LIBUSB_ENDPOINT_OUT,
         .driver = &corsairlink_driver_coolit,
         .led_control_count = 1,
         .fan_control_count = 4,
@@ -121,8 +116,7 @@ struct corsair_device_info corsairlink_devices[] = {
         .device_id = 0x3c,
         .name = "H100i",
         .read_endpoint = 0x01 | LIBUSB_ENDPOINT_IN,
-        .write_endpoint =
-            LIBUSB_REQUEST_TYPE_CLASS | LIBUSB_RECIPIENT_INTERFACE | LIBUSB_ENDPOINT_OUT,
+        .write_endpoint = 0x00 | LIBUSB_ENDPOINT_OUT,
         .driver = &corsairlink_driver_coolit,
         .led_control_count = 1,
         .fan_control_count = 4,
@@ -134,8 +128,7 @@ struct corsair_device_info corsairlink_devices[] = {
         .device_id = 0x3d,
         .name = "Commander Mini", /** Whiptail */
         .read_endpoint = 0x01 | LIBUSB_ENDPOINT_IN,
-        .write_endpoint =
-            LIBUSB_REQUEST_TYPE_CLASS | LIBUSB_RECIPIENT_INTERFACE | LIBUSB_ENDPOINT_OUT,
+        .write_endpoint = 0x00 | LIBUSB_ENDPOINT_OUT,
         .driver = &corsairlink_driver_coolit,
         .led_control_count = 1,
         .fan_control_count = 4,
@@ -147,8 +140,7 @@ struct corsair_device_info corsairlink_devices[] = {
         .device_id = 0x40,
         .name = "H100i GT", /** H100i */
         .read_endpoint = 0x01 | LIBUSB_ENDPOINT_IN,
-        .write_endpoint =
-            LIBUSB_REQUEST_TYPE_CLASS | LIBUSB_RECIPIENT_INTERFACE | LIBUSB_ENDPOINT_OUT,
+        .write_endpoint = 0x00 | LIBUSB_ENDPOINT_OUT,
         .driver = &corsairlink_driver_coolit,
         .led_control_count = 1,
         .fan_control_count = 4,
@@ -160,8 +152,7 @@ struct corsair_device_info corsairlink_devices[] = {
         .device_id = 0x41,
         .name = "H110i GT", /** H110i GT*/
         .read_endpoint = 0x01 | LIBUSB_ENDPOINT_IN,
-        .write_endpoint =
-            LIBUSB_REQUEST_TYPE_CLASS | LIBUSB_RECIPIENT_INTERFACE | LIBUSB_ENDPOINT_OUT,
+        .write_endpoint = 0x00 | LIBUSB_ENDPOINT_OUT,
         .driver = &corsairlink_driver_coolit,
         .led_control_count = 1,
         .fan_control_count = 2,
@@ -173,8 +164,7 @@ struct corsair_device_info corsairlink_devices[] = {
         .device_id = 0x42,
         .name = "H110i", /** H110i */
         .read_endpoint = 0x01 | LIBUSB_ENDPOINT_IN,
-        .write_endpoint =
-            LIBUSB_REQUEST_TYPE_CLASS | LIBUSB_RECIPIENT_INTERFACE | LIBUSB_ENDPOINT_OUT,
+        .write_endpoint = 0x00 | LIBUSB_ENDPOINT_OUT,
         .driver = &corsairlink_driver_coolit,
         .led_control_count = 1,
         .fan_control_count = 2,


### PR DESCRIPTION
## Proposed changes

In these cases the writes correctly go through the control/default/zero endpoint.  However, the `.write_endpoint field` for these devices was incorrectly computed and the resulting endpoint address was invalid (e.g. bit 5, set by `LIBUSB_REQUEST_TYPE_CLASS`, is reserved in endpoint addresses).

In fact, neither `LIBUSB_REQUEST_TYPE_CLASS` nor `LIBUSB_RECIPIENT_INTERFACE` had a place in this definition: these flags should only be used to build `bmRequestType` parameters for control transfers.

The issue was only harmless because `.write_endpoint` is not used in `corsairlink_coolit_write`.  This patch avoids future confusion about this.¹

¹ Related: #214 

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/audiohacked/OpenCorsairLink/blob/testing/CONTRIBUTING.md) doc
- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your master!
- [x] Make sure you are making a pull request against the **testing branch** (left side). Also you should start *your branch* off *our testing*.
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Check the commit's or even all commits' message styles matches our requested structure.