### PR TITLE
Fix issue 234: machine readable format for asetekpro pump

### DIFF
--- a/logic/settings/hydro_asetekpro.c
+++ b/logic/settings/hydro_asetekpro.c
@@ -71,6 +71,7 @@ hydro_asetekpro_settings(
         double temperature;
         rr = dev->driver->temperature.read( dev, handle, ii, &temperature );
         msg_info( "Temperature %d: %5.2f C\n", ii, temperature );
+        msg_machine( "temperature:%d:%5.2f\n", ii, temperature );
     }
 
     /* get number of fans */
@@ -88,6 +89,9 @@ hydro_asetekpro_settings(
         msg_info(
             "\tCurrent/Max Speed %i/%i RPM\n", readings.fan_ctrl.speed_rpm,
             settings.fan_ctrl.max_speed );
+        msg_machine(
+            "fan:%d:%d:%i:%i\n", ii, readings.fan_ctrl.mode, readings.fan_ctrl.speed_rpm,
+            readings.fan_ctrl.max_speed );
     }
 
     rr = dev->driver->pump.profile.read_profile( dev, handle, &readings.pump_ctrl );
@@ -95,6 +99,9 @@ hydro_asetekpro_settings(
     msg_info( "Pump:\tMode 0x%02X (%s)\n", readings.pump_ctrl.mode, AsetekProPumpModes_String[readings.pump_ctrl.mode] );
     msg_info(
         "\tCurrent/Max Speed %i/%i RPM\n", readings.pump_ctrl.speed, readings.pump_ctrl.max_speed );
+    msg_machine(
+        "pump:%d:%i:%i\n", readings.pump_ctrl.mode, readings.pump_ctrl.speed,
+        readings.pump_ctrl.max_speed );
 
     if ( flags.set_led == 1 )
     {


### PR DESCRIPTION
## Proposed changes

This commit adds support for the ``--machine`` option to the asetekpro pump so that it produces machine readable output for the values of the temperature, fans and pump.

## Types of changes

What types of changes does your code introduce to OpenCorsairLink?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/audiohacked/OpenCorsairLink/blob/testing/CONTRIBUTING.md) doc
- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your master!
- [x] Make sure you are making a pull request against the **testing branch** (left side). Also you should start *your branch* off *our testing*.
- [ x Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Check the commit's or even all commits' message styles matches our requested structure.

## Further comments

The fix was to simply add calls to the ``msg_machine()`` method similar to what already exists in the ``hydro_asetek.c`` file.

I have tested this with a H150i Pro and it produces output like:

```
temperature:0:33.70
fan:0:0:604:0
fan:1:0:618:0
fan:2:0:600:0
pump:2:2820:0
```

This change should work with other devices that use the asetekpro pump
