### PR TITLE
docs: fix simple typo, translage -> translate

### DIFF
--- a/include/protocol/asetekpro.h
+++ b/include/protocol/asetekpro.h
@@ -22,7 +22,7 @@
 #include <stdint.h>
 
 /*
- * These two defines are used to translage options into different item:
+ * These two defines are used to translate options into different item:
  *   - an enum for values
  *   - a list of string values 
  *


### PR DESCRIPTION
There is a small typo in include/protocol/asetekpro.h.

Should read `translate` rather than `translage`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md